### PR TITLE
Small bugfix, now iterates over users.links like dbs and instances.

### DIFF
--- a/reddwarfclient/cli.py
+++ b/reddwarfclient/cli.py
@@ -213,8 +213,8 @@ class UserCommands(object):
             users = dbaas.users.list(id, limit, marker)
             for user in users:
                 _pretty_print(user._info)
-            if users.next:
-                for link in users.next:
+            if users.links:
+                for link in users.links:
                     _pretty_print(link)
         except:
             print sys.exc_info()[1]


### PR DESCRIPTION
Don't worry, this only affects the CLI tool and not the API, which is fine.
Since paged content returns .next (the marker) and .links (which contains the next link), the CLI needs to iterate over the links and not the marker.
