### PR TITLE
Changed client to allow custom Authenticator classes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,11 @@ import setuptools
 import sys
 
 
-requirements = []
+requirements = ["httplib2", "prettytable"]
+if sys.version_info < (2, 6):
+    requirements.append("simplejson")
+if sys.version_info < (2, 7):
+    requirements.append("argparse")
 
 
 def read_file(file_name):


### PR DESCRIPTION
- This allows a user to specify a custom strategy. The motivation is to locally run fake mode without having to fake keystone.
- Updated the setup.py with the project's requirements (swiped from Nova Client's).
