### PR TITLE
Support for root user reset-password action

### DIFF
--- a/reddwarfclient/cli.py
+++ b/reddwarfclient/cli.py
@@ -121,7 +121,16 @@ class InstanceCommands(object):
         except:
             print sys.exc_info()[1]
 
-
+    def reset_password(self, id):
+        """Reset the root user Password"""
+        dbaas = common.get_client()
+        try:
+            result = dbaas.instances.reset_password(id)
+            if result:
+                _pretty_print(result)
+        except:
+            print sys.exc_info()[1]
+            
 class FlavorsCommands(object):
     """Commands for listing Flavors"""
 

--- a/reddwarfclient/instances.py
+++ b/reddwarfclient/instances.py
@@ -122,6 +122,7 @@ class Instances(base.ManagerWithFind):
         url = "/instances/%s/action" % instance_id
         resp, body = self.api.client.post(url, body=body)
         check_for_exceptions(resp, body)
+        return body
 
     def resize_volume(self, instance_id, volume_size):
         """
@@ -146,7 +147,15 @@ class Instances(base.ManagerWithFind):
         body = {'restart': {}}
         self._action(instance_id, body)
 
+    def reset_password(self, instance_id):
+        """
+        Resets the database instance root password.
 
+        :param instance_id: The :class:`Instance` (or its ID) to share onto.
+        """
+        body = {'reset-password': {}}
+        return self._action(instance_id, body)
+        
 class InstanceStatus(object):
 
     ACTIVE = "ACTIVE"


### PR DESCRIPTION
I've implemented 'reset-password' as an additional action on an instance.  We have stubbed out the user and database management portions of the Reddwarf API and return a 501 Not Implemented.
