### PR TITLE
Added a ton of CLI options, plus fixed a CI bug.

### DIFF
--- a/reddwarfclient/cli.py
+++ b/reddwarfclient/cli.py
@@ -18,6 +18,7 @@
 Reddwarf Command line tool
 """
 
+#TODO(tim.simpson): optparse is deprecated. Replace with argparse.
 import optparse
 import os
 import sys
@@ -36,7 +37,7 @@ if os.path.exists(os.path.join(possible_topdir, 'reddwarfclient',
 from reddwarfclient import common
 
 
-class InstanceCommands(common.CommandsBase):
+class InstanceCommands(common.AuthedCommandsBase):
     """Commands to perform various instances operations and actions"""
 
     params = [
@@ -93,17 +94,17 @@ class InstanceCommands(common.CommandsBase):
         self._pretty_print(self.dbaas.instances.restart, self.id)
 
 
-class FlavorsCommands(common.CommandsBase):
+class FlavorsCommands(common.AuthedCommandsBase):
     """Commands for listing Flavors"""
 
     params = []
 
     def list(self):
         """List the available flavors"""
-        self._pretty_print(self.dbaas.flavors.list)
+        self._pretty_list(self.dbaas.flavors.list)
 
 
-class DatabaseCommands(common.CommandsBase):
+class DatabaseCommands(common.AuthedCommandsBase):
     """Database CRUD operations on an instance"""
 
     params = [
@@ -130,7 +131,7 @@ class DatabaseCommands(common.CommandsBase):
         self._pretty_paged(self.dbaas.databases.list, self.id)
 
 
-class UserCommands(common.CommandsBase):
+class UserCommands(common.AuthedCommandsBase):
     """User CRUD operations on an instance"""
     params = [
               'id',
@@ -159,7 +160,7 @@ class UserCommands(common.CommandsBase):
         self._pretty_paged(self.dbaas.users.list, self.id)
 
 
-class RootCommands(common.CommandsBase):
+class RootCommands(common.AuthedCommandsBase):
     """Root user related operations on an instance"""
 
     params = [
@@ -181,7 +182,7 @@ class RootCommands(common.CommandsBase):
         self._pretty_print(self.dbaas.root.is_root_enabled, self.id)
 
 
-class VersionCommands(common.CommandsBase):
+class VersionCommands(common.AuthedCommandsBase):
     """List available versions"""
 
     params = [
@@ -192,31 +193,6 @@ class VersionCommands(common.CommandsBase):
         """List all the supported versions"""
         self._require('url')
         self._pretty_print(self.dbaas.versions.index, self.url)
-
-
-def config_options(oparser):
-    oparser.add_option("--auth_url", default="http://localhost:5000/v2.0",
-                       help="Auth API endpoint URL with port and version. \
-                            Default: http://localhost:5000/v2.0")
-    oparser.add_option("--username", help="Login username")
-    oparser.add_option("--apikey", help="Api key")
-    oparser.add_option("--tenant_id",
-                       help="Tenant Id associated with the account")
-    oparser.add_option("--auth_type", default="keystone",
-                       help="Auth type to support different auth environments, \
-                            Supported values are 'keystone', 'rax'.")
-    oparser.add_option("--service_type", default="reddwarf",
-                       help="Service type is a name associated for the catalog")
-    oparser.add_option("--service_name", default="Reddwarf",
-                       help="Service name as provided in the service catalog")
-    oparser.add_option("--service_url", default="",
-                       help="Service endpoint to use if the catalog doesn't \
-                            have one")
-    oparser.add_option("--region", default="RegionOne",
-                       help="Region the service is located in")
-    oparser.add_option("-i", "--insecure", action="store_true",
-                       dest="insecure", default=False,
-                       help="Run in insecure mode for https endpoints.")
 
 
 COMMANDS = {'auth': common.Auth,
@@ -230,10 +206,7 @@ COMMANDS = {'auth': common.Auth,
 
 def main():
     # Parse arguments
-    oparser = optparse.OptionParser(usage="%prog [options] <cmd> <action> <args>",
-                                    version='1.0',
-                                    conflict_handler='resolve')
-    config_options(oparser)
+    oparser = common.CliOptions.create_optparser()
     for k, v in COMMANDS.items():
         v._prepare_parser(oparser)
     (options, args) = oparser.parse_args()
@@ -241,11 +214,21 @@ def main():
     if not args:
         common.print_commands(COMMANDS)
 
+    if options.verbose:
+        os.environ['RDC_PP']  = "True"
+        os.environ['REDDWARFCLIENT_DEBUG'] = "True"
+
     # Pop the command and check if it's in the known commands
     cmd = args.pop(0)
     if cmd in COMMANDS:
         fn = COMMANDS.get(cmd)
-        command_object = fn(oparser)
+        command_object = None
+        try:
+            command_object = fn(oparser)
+        except Exception as ex:
+            if options.debug:
+                raise
+            print(ex)
 
         # Get a list of supported actions for the command
         actions = common.methods_of(command_object)
@@ -256,10 +239,15 @@ def main():
         # Check for a valid action and perform that action
         action = args.pop(0)
         if action in actions:
-            try:
+            if not options.debug:
+                try:
+                    getattr(command_object, action)()
+                except Exception as ex:
+                    if options.debug:
+                        raise
+                    print ex
+            else:
                 getattr(command_object, action)()
-            except Exception as ex:
-                print ex
         else:
             common.print_actions(cmd, actions)
     else:

--- a/reddwarfclient/exceptions.py
+++ b/reddwarfclient/exceptions.py
@@ -41,6 +41,20 @@ class EndpointNotFound(Exception):
     pass
 
 
+class AuthUrlNotGiven(EndpointNotFound):
+    """The auth url was not given."""
+    pass
+
+
+class ServiceUrlNotGiven(EndpointNotFound):
+    """The service url was not given."""
+    pass
+
+
+class ResponseFormatError(Exception):
+    """Could not parse the response format."""
+    pass
+
 class AmbiguousEndpoints(Exception):
     """Found more than one matching endpoint in Service Catalog."""
     def __init__(self, endpoints=None):
@@ -159,4 +173,5 @@ def from_response(response, body):
             details = error.get('details', None)
         return cls(code=response.status, message=message, details=details)
     else:
+        request_id = response.get('x-compute-request-id')
         return cls(code=response.status, request_id=request_id)

--- a/reddwarfclient/xml.py
+++ b/reddwarfclient/xml.py
@@ -2,6 +2,7 @@ from lxml import etree
 import json
 from numbers import Number
 
+from reddwarfclient import exceptions
 from reddwarfclient.client import ReddwarfHTTPClient
 
 
@@ -196,7 +197,10 @@ class ReddwarfXmlClient(ReddwarfHTTPClient):
         # The root XML element always becomes a dictionary with a single
         # field, which has the same key as the elements name.
         result = {}
-        root_element = etree.XML(body_string)
+        try:
+            root_element = etree.XML(body_string)
+        except etree.XMLSyntaxError:
+            raise exceptions.ResponseFormatError()
         root_name = normalize_tag(root_element)
         root_value, links = root_element_to_json(root_name, root_element)
         result = { root_name:root_value }


### PR DESCRIPTION
- Renamed the auth_type "basic" to the more apt "auth1.1".
- Made it possible to pass an "token" and "service_url" argument alone to
  the client. It wouldn't work with just this before.
- The client now saves all arguments you give it to the pickled file,
  including the auth strategy, and preserves the token and service_url
  (which it didn't before) which makes exotic auth types such as "fake"
  easier to work with.
- Not raising an error for a lack of an auth_url until auth occurs
  (which is usually right after creation of the client anyway for most
  auth types).
- Moved oparser code into CliOption class. This is where the options live
  plus is the name of that pickled file that gets stored on login.
- Added a "debug" option which avoids swallowing stack traces if
  something goes wrong with the CLI. Should make client work much easier.
- Added a "verbose" option which changes the output to instead show the
  simulated CURL statement plus the request and response headers and
  bodies, which is useful because I...
- Added an "xml" option which does all the communication in XML.
- Fixed a bug which was affecting the CI tests where the client would fail
  if the response body could not be parsed.
